### PR TITLE
Warn on external resource with updated element

### DIFF
--- a/webpack-subresource-integrity-embroider/index.js
+++ b/webpack-subresource-integrity-embroider/index.js
@@ -4,6 +4,38 @@ const { createHash } = require("node:crypto");
 const path = require("node:path");
 
 class SubresourceIntegrityPlugin {
+  async getResourceContent(resourcePath) {
+    if (resourcePath.startsWith("http")) {
+      const response = await fetch(resourcePath);
+      const arrayBuffer = await response.arrayBuffer();
+      return Buffer.from(arrayBuffer);
+    }
+
+    return readFile(resourcePath);
+  }
+
+  generateExternalResourceError(fileName, hashAlgorithm, fileHash, element) {
+    element.setAttribute("integrity", `${hashAlgorithm}-${fileHash}`);
+    element.setAttribute("crossorigin", "anonymous");
+
+    const text = `\x1b[31m\n🚨 The ${fileName} resource is served from an external URL and does not contain an integrity hash. We have hashed the file as it exists today, we don't automatically apply this so you can detect when an external resource has been changed.
+
+If you trust the file please update the resource as follows in your index.html:
+
+${element.outerHTML}`;
+
+    element.removeAttribute("integrity");
+    element.removeAttribute("crossorigin");
+
+    return text;
+  }
+
+  async generateHash(hashAlgorithm, resourceLocation) {
+    return createHash(hashAlgorithm)
+      .update(await this.getResourceContent(resourceLocation))
+      .digest("base64");
+  }
+
   apply(compiler) {
     compiler.hooks.done.tapPromise(
       "WriteSRIToIndexHtmlPlugin",
@@ -15,6 +47,7 @@ class SubresourceIntegrityPlugin {
         const scriptElements =
           indexHtml.window.document.querySelectorAll("script");
         const linkElements = indexHtml.window.document.querySelectorAll("link");
+        const fileErrors = [];
         await Promise.all(
           [...scriptElements, ...linkElements].map(async (element) => {
             // calculate integrity
@@ -25,15 +58,31 @@ class SubresourceIntegrityPlugin {
                 : element.getAttribute("href");
             // strip publishPath from locations
             const fileName = assetLocation.replace(publicPath, "/");
+            const currentIntegrity = element.getAttribute("integrity");
 
             if (fileName === "/ember-cli-live-reload.js") {
               // ember-cli-live-reload.js does not exist on disk
               return;
             }
 
-            const fileHash = createHash(hashAlgorithm)
-              .update(await readFile(path.join(outputPath, fileName)))
-              .digest("base64");
+            if (fileName.startsWith("http")) {
+              if (currentIntegrity) return;
+              const fileHash = await this.generateHash(hashAlgorithm, fileName);
+
+              fileErrors.push(
+                this.generateExternalResourceError(
+                  fileName,
+                  hashAlgorithm,
+                  fileHash,
+                  element,
+                ),
+              );
+
+              return;
+            }
+
+            const filePath = path.join(outputPath, fileName);
+            const fileHash = await this.generateHash(hashAlgorithm, filePath);
 
             // set integrity attribute
             element.setAttribute("integrity", `${hashAlgorithm}-${fileHash}`);
@@ -41,6 +90,11 @@ class SubresourceIntegrityPlugin {
             element.setAttribute("crossorigin", "anonymous");
           }),
         );
+
+        if (fileErrors.length > 0) {
+          throw new Error(fileErrors.join("\n\n------\n"));
+        }
+
         await writeFile(indexHtmlPath, indexHtml.serialize());
       },
     );

--- a/webpack-subresource-integrity-embroider/index.js
+++ b/webpack-subresource-integrity-embroider/index.js
@@ -19,11 +19,12 @@ class SubresourceIntegrityPlugin {
           [...scriptElements, ...linkElements].map(async (element) => {
             // calculate integrity
             const hashAlgorithm = "sha384";
-            const assetLocation = element.tagName === "SCRIPT"
+            const assetLocation =
+              element.tagName === "SCRIPT"
                 ? element.getAttribute("src")
                 : element.getAttribute("href");
             // strip publishPath from locations
-            const fileName = assetLocation.replace(publicPath, '/');
+            const fileName = assetLocation.replace(publicPath, "/");
 
             if (fileName === "/ember-cli-live-reload.js") {
               // ember-cli-live-reload.js does not exist on disk

--- a/webpack-subresource-integrity-embroider/index.js
+++ b/webpack-subresource-integrity-embroider/index.js
@@ -25,9 +25,8 @@ class SubresourceIntegrityPlugin {
             // strip publishPath from locations
             const fileName = assetLocation.replace(publicPath, '/');
 
-            if (fileName.startsWith("http") || fileName === "/ember-cli-live-reload.js") {
+            if (fileName === "/ember-cli-live-reload.js") {
               // ember-cli-live-reload.js does not exist on disk
-              // skip external resources
               return;
             }
 

--- a/webpack-subresource-integrity-embroider/index.js
+++ b/webpack-subresource-integrity-embroider/index.js
@@ -8,9 +8,7 @@ class SubresourceIntegrityPlugin {
     compiler.hooks.done.tapPromise(
       "WriteSRIToIndexHtmlPlugin",
       async (stats) => {
-        const statsJson = stats.toJson();
-        const buildPath = statsJson.outputPath;
-        const publicPath = statsJson.publicPath;
+        const { buildPath, publicPath } = stats.toJson();
         const indexHtmlPath = path.join(buildPath, "index.html");
         const indexHtmlContent = await readFile(indexHtmlPath, "utf-8");
         const indexHtml = new JSDOM(indexHtmlContent);
@@ -20,7 +18,7 @@ class SubresourceIntegrityPlugin {
         await Promise.all(
           [...scriptElements, ...linkElements].map(async (element) => {
             // calculate integrity
-            const hashAlgorith = "sha384";
+            const hashAlgorithm = "sha384";
             const assetLocation = element.tagName === "SCRIPT"
                 ? element.getAttribute("src")
                 : element.getAttribute("href");
@@ -33,12 +31,12 @@ class SubresourceIntegrityPlugin {
               return;
             }
 
-            const fileHash = createHash(hashAlgorith)
+            const fileHash = createHash(hashAlgorithm)
               .update(await readFile(path.join(buildPath, fileName)))
               .digest("base64");
 
             // set integrity attribute
-            element.setAttribute("integrity", `${hashAlgorith}-${fileHash}`);
+            element.setAttribute("integrity", `${hashAlgorithm}-${fileHash}`);
             // set crossorigin attribute
             element.setAttribute("crossorigin", "anonymous");
           }),

--- a/webpack-subresource-integrity-embroider/index.js
+++ b/webpack-subresource-integrity-embroider/index.js
@@ -8,8 +8,8 @@ class SubresourceIntegrityPlugin {
     compiler.hooks.done.tapPromise(
       "WriteSRIToIndexHtmlPlugin",
       async (stats) => {
-        const { buildPath, publicPath } = stats.toJson();
-        const indexHtmlPath = path.join(buildPath, "index.html");
+        const { outputPath, publicPath } = stats.toJson();
+        const indexHtmlPath = path.join(outputPath, "index.html");
         const indexHtmlContent = await readFile(indexHtmlPath, "utf-8");
         const indexHtml = new JSDOM(indexHtmlContent);
         const scriptElements =
@@ -31,7 +31,7 @@ class SubresourceIntegrityPlugin {
             }
 
             const fileHash = createHash(hashAlgorithm)
-              .update(await readFile(path.join(buildPath, fileName)))
+              .update(await readFile(path.join(outputPath, fileName)))
               .digest("base64");
 
             // set integrity attribute


### PR DESCRIPTION
An option where we generate the hash for the user.

Outputs an error like

<img width="1038" alt="image" src="https://github.com/evoactivity/webpack-subresource-integrity-embroider/assets/83799/5e949fa0-1eb9-4fd0-9d25-eadcef63c581">
